### PR TITLE
Migrate guides and concepts from plexapi-dev-docs

### DIFF
--- a/Intro.mdx
+++ b/Intro.mdx
@@ -5,15 +5,26 @@ description: "Welcome to the PlexAPI.dev documentation site"
 
 Hello Plex community!
 
-[PlexAPI.dev](https://plexapi.dev) is the new home for Plex Media Server developer resources. This site hosts the OpenAPI-powered API reference, SDKs, guides, and community documentation for building integrations with Plex Media Server.
+[PlexAPI.dev](https://plexapi.dev) is the home for Plex Media Server developer resources. This site hosts the OpenAPI-powered API reference, SDKs, guides, and community documentation for building integrations with Plex Media Server.
 
 ## What you'll find here
 
+- **[Quick Start](/quick-start)** – Make your first authenticated Plex API call in under five minutes.
+- **[Authentication](/authentication)** – How to obtain and safely use Plex tokens.
 - **[API Reference](/api-reference)** – Endpoint documentation generated from the Plex Media Server OpenAPI specification, with request/response examples and code snippets.
+- **[Core concepts](/concepts/library)** – Overviews of libraries, server identity, and sessions.
 - **[OpenAPI Specification](/Open-API-Specification)** – How the canonical API contract is maintained and how it powers the docs and SDKs.
 - **[SDKs](/SDKs)** – Official and community SDKs in popular languages, generated from the same OpenAPI contract.
 - **[Contributing](/contributing)** – How to suggest edits, open issues, and help improve the docs and specification.
 - **[Other Resources](/other-resources)** – Additional community references and documentation.
+
+## Prerequisites
+
+Most examples assume:
+
+- A running Plex Media Server you can access.
+- A Plex authentication token (see [Authentication](/authentication)).
+- Basic familiarity with REST APIs and JSON.
 
 ## Getting involved
 

--- a/Open-API-Specification.mdx
+++ b/Open-API-Specification.mdx
@@ -3,7 +3,7 @@ title: "OpenAPI Specification"
 description: "The canonical API contract that powers PlexAPI.dev"
 ---
 
-The [Plex Media Server OpenAPI specification](https://github.com/LukasParke/plexapi-dev-docs/blob/main/spec/plex-media-server.openapi.json) is the canonical API contract for PlexAPI.dev. The [API reference](/api-reference) on this site and the [SDKs](/SDKs) are generated from this specification.
+The [Plex Media Server OpenAPI specification](https://github.com/LukasParke/plex-api-spec/blob/main/plex-api-spec.yaml) is the canonical API contract for PlexAPI.dev. The [API reference](/api-reference) on this site and the [SDKs](/SDKs) are generated from this specification.
 
 ## What is OpenAPI?
 
@@ -11,7 +11,7 @@ OpenAPI is a standard format for describing REST APIs. It lets tools generate in
 
 ## The PlexAPI.dev specification
 
-The canonical specification is maintained in the [PlexAPI.dev monorepo](https://github.com/LukasParke/plexapi-dev-docs) at `spec/plex-media-server.openapi.json`. It describes the Plex Media Server endpoints, request parameters, response shapes, authentication, and error handling that the docs and SDKs rely on.
+The canonical specification is maintained in the [plex-api-spec](https://github.com/LukasParke/plex-api-spec) repository as `plex-api-spec.yaml`. It describes the Plex Media Server endpoints, request parameters, response shapes, authentication, and error handling that the docs and SDKs rely on.
 
 ## How this site uses the specification
 

--- a/authentication.mdx
+++ b/authentication.mdx
@@ -1,0 +1,179 @@
+---
+title: "Authentication"
+description: "How to obtain and use Plex Media Server API tokens safely"
+---
+
+# Authentication
+
+Most Plex Media Server API endpoints require an authentication token. This guide explains what Plex tokens are, how to obtain one safely, and how to use and protect them in your integrations.
+
+## What is a Plex token?
+
+A Plex token is a long-lived credential that proves who you are to Plex services. Two token shapes matter to API developers:
+
+| Token type | What it does | Where it is used |
+|------------|--------------|------------------|
+| **Server token** (`X-Plex-Token`) | Grants access to a specific Plex Media Server. | Sent with every request to that server. |
+| **Plex.tv token** | Authenticates your Plex account against Plex's cloud services. | Used to discover servers, manage account settings, and request server tokens remotely. |
+
+This guide focuses on the server token because it is what you send with every API call to a Plex Media Server.
+
+## Before you begin
+
+You will need:
+
+- A Plex account.
+- Access to a Plex Media Server (your own, or one you have been invited to).
+- A way to store secrets securely, such as environment variables or a secrets manager.
+
+## Find your server URL
+
+Most local API examples use the server's LAN address:
+
+```
+http://<server-ip>:32400
+```
+
+If you access Plex through a reverse proxy or remote access, use that HTTPS URL instead. Some requests, such as the root identity endpoint, work without a token; everything under `/library`, `/status`, and most other paths requires one.
+
+## Obtain a server token
+
+### Option 1: Copy a token from the Plex Web App (fastest for personal scripts)
+
+The Plex Web App already has a valid token for your server. You can copy it from the browser's network tools:
+
+1. Open your Plex server in a web browser and sign in.
+2. Open the browser developer tools and go to the **Network** tab.
+3. Refresh a library or perform any action that triggers a request to your server.
+4. Select a request whose URL points to your server, for example `.../library/sections`.
+5. Look for the `X-Plex-Token` query parameter or request header.
+6. Copy the token value and store it securely.
+
+<Tip>
+The token shown is tied to your signed-in account. If you share the server with others, each account has its own token.
+</Tip>
+
+### Option 2: Request a token from Plex.tv
+
+For applications that cannot open a browser, you can authenticate with Plex.tv and exchange credentials for a token. This requires your Plex username and password and is best done with a small helper script or an OAuth-style sign-in flow. A full example is beyond the scope of this guide; for now, store any Plex.tv token as securely as a server token.
+
+### Option 3: Use an account setting or claim token
+
+When setting up a new server, Plex uses a short-lived **claim token** to link the server to your account. Claim tokens expire quickly and are not used for routine API calls. After the server is claimed, use one of the methods above to get a long-lived token.
+
+## Send the token with each request
+
+Include the token on every request to a protected endpoint. The preferred method is the `X-Plex-Token` header:
+
+```bash
+curl -H "X-Plex-Token: $PLEX_TOKEN" \
+  "$PLEX_SERVER_URL/library/sections"
+```
+
+You can also send the token as a query parameter, which is useful for quick browser tests:
+
+```bash
+curl "$PLEX_SERVER_URL/library/sections?X-Plex-Token=$PLEX_TOKEN"
+```
+
+<Warning>
+The query parameter can appear in server logs, proxy logs, and browser history. Prefer the header for production code.
+</Warning>
+
+## Identify your client
+
+Plex expects API clients to identify themselves with a few extra headers. These headers help server administrators see which clients are connected and help Plex enforce rate limits or compatibility checks. Include them whenever possible:
+
+| Header | Example | Purpose |
+|--------|---------|---------|
+| `X-Plex-Client-Identifier` | `my-dashboard-1234` | A unique ID for your application or installation. |
+| `X-Plex-Product` | `My Plex Dashboard` | Human-readable product name. |
+| `X-Plex-Version` | `1.0.0` | Version of your client. |
+| `X-Plex-Device` | `Linux` | The device or platform running the client. |
+| `X-Plex-Device-Name` | `office-pi` | A friendly name for the device. |
+
+Example request with identification headers:
+
+```bash
+curl -H "X-Plex-Token: $PLEX_TOKEN" \
+  -H "X-Plex-Client-Identifier: my-dashboard-1234" \
+  -H "X-Plex-Product: My Plex Dashboard" \
+  -H "X-Plex-Version: 1.0.0" \
+  -H "X-Plex-Device: Linux" \
+  -H "X-Plex-Device-Name: office-pi" \
+  "$PLEX_SERVER_URL/library/sections"
+```
+
+Choose an `X-Plex-Client-Identifier` that is stable for the lifetime of your app installation. Generating a new UUID on every restart is fine for experiments, but stable IDs are better for dashboards and automation that run continuously.
+
+## Token scope and managed users
+
+The token you use determines what the API can see:
+
+- **Server owner token** — full access to libraries, settings, and sessions.
+- **Home user token** — limited to the libraries and permissions granted by the owner.
+- **Friend/shared user token** — limited to the shared libraries the owner chose.
+
+If your integration behaves differently than expected, confirm the token belongs to the intended account and that the account has permission for the library or action.
+
+## Environment-variable handling
+
+A minimal, safe pattern is to read the token and server URL from the environment at startup and fail fast if either is missing:
+
+```js
+const serverUrl = process.env.PLEX_SERVER_URL;
+const token = process.env.PLEX_TOKEN;
+
+if (!serverUrl || !token) {
+  throw new Error("PLEX_SERVER_URL and PLEX_TOKEN are required");
+}
+```
+
+```py
+import os
+
+server_url = os.environ.get("PLEX_SERVER_URL")
+token = os.environ.get("PLEX_TOKEN")
+
+if not server_url or not token:
+    raise ValueError("PLEX_SERVER_URL and PLEX_TOKEN are required")
+```
+
+For local development, use a `.env` file loaded by your application, and add `.env` to `.gitignore`.
+
+## Token rotation
+
+If a token is exposed:
+
+1. Revoke it by signing the affected device or account out of Plex.
+2. Generate or copy a new token using one of the methods above.
+3. Update the token in your secrets manager or environment.
+4. Restart your integration.
+
+For automation that runs on a server, consider using a dedicated managed user or app-specific token where possible so rotation does not affect your personal devices.
+
+## Security best practices
+
+Treat your Plex token like a password. Anyone with the token can act as you on that server.
+
+- **Never commit tokens to source control.** Load them from environment variables or a secrets manager.
+- **Never expose tokens in public documentation, screenshots, or examples.** Use placeholder values such as `<your-token>`.
+- **Prefer HTTPS when accessing a server remotely.** HTTP is acceptable on trusted local networks, but it sends the token in plain text.
+- **Rotate tokens if you suspect leakage.** You can sign out other devices from your Plex account settings, which invalidates existing tokens.
+- **Scope tokens by user.** When building tools for others, authenticate as that user rather than reusing an owner token.
+- **Do not log tokens or full request URLs.** Redact `X-Plex-Token` and any `X-Plex-Token` query parameter from logs.
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to try |
+|---------|--------------|-------------|
+| `401 Unauthorized` | Token is missing, expired, or invalid. | Verify the token value and that the account can access the server. |
+| `403 Forbidden` | Account lacks permission. | Check that the user owns or has been shared the library you are querying. |
+| Empty library list | Token belongs to the wrong account. | Confirm which account the token was copied from. |
+| SSL errors | Self-signed or mismatched certificate. | Use the correct HTTPS hostname, or use HTTP only on trusted local networks. |
+
+## Next steps
+
+- Follow the [Quick Start](./quick-start) to make your first authenticated API call.
+- Review the [API Reference](/api-reference) for endpoints that accept the token.
+- Read the [SDKs](/SDKs) page to see how client libraries handle tokens and client identification.

--- a/concepts/library.mdx
+++ b/concepts/library.mdx
@@ -1,0 +1,41 @@
+---
+title: "Libraries"
+description: "How Plex Media Server organizes media into libraries and how to query them"
+---
+
+# Libraries
+
+Library sections and the items they contain.
+
+## List library sections
+
+```http
+GET /library/sections
+```
+
+Returns all configured library sections, such as movies, TV shows, music, and photos.
+
+### Response
+
+```json
+{
+  "MediaContainer": {
+    "size": 2,
+    "Directory": [
+      {
+        "key": "1",
+        "type": "movie",
+        "title": "Movies"
+      }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | `string` | Section identifier. |
+| `type` | `string` | Section type: `movie`, `show`, `artist`, or `photo`. |
+| `title` | `string` | Display name. |
+
+See the [Quick Start](/quick-start) for a runnable example, and the [API Reference](/api-reference) for the full endpoint schema.

--- a/concepts/server.mdx
+++ b/concepts/server.mdx
@@ -1,0 +1,37 @@
+---
+title: "Server"
+description: "Server discovery, identity, and top-level status for Plex Media Server"
+---
+
+# Server
+
+Server discovery, identity, and top-level status.
+
+## Get server identity
+
+```http
+GET /identity
+```
+
+Returns the server's identity, including its unique machine identifier. This endpoint does **not** require authentication and is useful for server discovery.
+
+### Response
+
+```json
+{
+  "MediaContainer": {
+    "size": 0,
+    "claimed": true,
+    "machineIdentifier": "abc123def456",
+    "version": "1.40.2.8395"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `machineIdentifier` | `string` | Unique identifier for this Plex server. |
+| `claimed` | `boolean` | Whether the server is claimed to a Plex account. |
+| `version` | `string` | Plex Media Server version. |
+
+See the [API Reference](/api-reference) for the full endpoint schema.

--- a/concepts/sessions.mdx
+++ b/concepts/sessions.mdx
@@ -1,0 +1,44 @@
+---
+title: "Sessions"
+description: "Active playback sessions and transcoding status for Plex Media Server"
+---
+
+# Sessions
+
+Active playback sessions and transcoding status.
+
+## List active sessions
+
+```http
+GET /status/sessions
+```
+
+Returns all currently active playback sessions.
+
+### Response
+
+```json
+{
+  "MediaContainer": {
+    "size": 1,
+    "Metadata": [
+      {
+        "ratingKey": "100",
+        "title": "The Shawshank Redemption",
+        "Player": {
+          "title": "Chrome",
+          "state": "playing"
+        }
+      }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Session.id` | `string` | Unique session identifier. |
+| `Player.title` | `string` | Player application name. |
+| `Player.state` | `string` | Playback state. |
+
+See the [API Reference](/api-reference) for the full endpoint schema.

--- a/contributing.mdx
+++ b/contributing.mdx
@@ -56,6 +56,18 @@ Before submitting changes:
 - Prefer the `X-Plex-Token` header over query parameters in examples.
 - Use American English spelling and avoid jargon where possible.
 
+## Detailed content style rules
+
+- **Sentence case for headings.** Use "Quick start", not "Quick Start".
+- **Write for the reader.** Start each guide with what the reader will accomplish and what they need first.
+- **Keep examples copy-pasteable.** Provide complete commands and include placeholders like `<your-token>` where sensitive data belongs.
+- **No real credentials.** Never include real Plex tokens, server addresses, or user metadata in examples or screenshots.
+- **Use relative links for internal pages.** For example, use `/quick-start` or `/concepts/library` instead of absolute URLs.
+- **Prefer the `X-Plex-Token` header.** Do not show tokens as query parameters unless the example specifically explains query-parameter usage.
+- **One sentence per line in source Markdown.** This makes diffs easier to read and review.
+- **Use American English spelling** and avoid jargon where possible.
+- **Check the build.** `mintlify validate` and `mintlify broken-links` catch structural and link errors before CI.
+
 ## Review process
 
 1. Open a pull request with a clear summary of the change.

--- a/docs.json
+++ b/docs.json
@@ -17,10 +17,20 @@
             "group": "Getting Started",
             "pages": [
               "Intro",
+              "quick-start",
+              "authentication",
               "Open-API-Specification",
               "SDKs",
               "other-resources",
               "contributing"
+            ]
+          },
+          {
+            "group": "Core concepts",
+            "pages": [
+              "concepts/library",
+              "concepts/server",
+              "concepts/sessions"
             ]
           }
         ]

--- a/quick-start.mdx
+++ b/quick-start.mdx
@@ -1,0 +1,201 @@
+---
+title: "Quick Start"
+description: "Make your first authenticated Plex Media Server API call in under five minutes"
+---
+
+# Quick Start
+
+This guide walks you through your first authenticated request to a Plex Media Server in under five minutes. It includes copy-pasteable examples for `curl`, Node.js, and Python.
+
+## Before you begin
+
+You will need:
+
+1. The address of your Plex server, for example `http://192.168.1.10:32400` or `https://plex.example.com`.
+2. A valid Plex token. See the [Authentication guide](./authentication) if you do not have one yet.
+3. `curl`, Node.js, or Python installed.
+
+## Set environment variables
+
+To keep the examples copy-pasteable, store your server URL and token in environment variables:
+
+<CodeGroup>
+```bash title="macOS / Linux"
+export PLEX_SERVER_URL="http://<your-server-ip>:32400"
+export PLEX_TOKEN="<your-token>"
+```
+
+```powershell title="Windows PowerShell"
+$env:PLEX_SERVER_URL="http://<your-server-ip>:32400"
+$env:PLEX_TOKEN="<your-token>"
+```
+</CodeGroup>
+
+<Warning>
+Never commit tokens to source control. Use environment variables or a secrets manager in production.
+</Warning>
+
+## Verify the server is reachable
+
+Plex Media Server exposes server identity and capabilities at the root path. This endpoint does not require a token on most local networks:
+
+<CodeGroup>
+```bash title="curl"
+curl "$PLEX_SERVER_URL/"
+```
+
+```js title="Node.js"
+const res = await fetch(`${process.env.PLEX_SERVER_URL}/`);
+console.log(await res.text());
+```
+
+```py title="Python"
+import os, urllib.request
+
+url = f"{os.environ['PLEX_SERVER_URL']}/"
+with urllib.request.urlopen(url) as res:
+    print(res.read().decode())
+```
+</CodeGroup>
+
+You should receive an XML `MediaContainer` response with the server name, version, and other metadata. If the request fails, confirm the server address and that the server is running.
+
+## List your libraries
+
+List the libraries on your server:
+
+<CodeGroup>
+```bash title="curl"
+curl -H "X-Plex-Token: $PLEX_TOKEN" \
+  -H "Accept: application/json" \
+  "$PLEX_SERVER_URL/library/sections"
+```
+
+```js title="Node.js"
+const res = await fetch(`${process.env.PLEX_SERVER_URL}/library/sections`, {
+  headers: {
+    "X-Plex-Token": process.env.PLEX_TOKEN,
+    "Accept": "application/json",
+  },
+});
+console.log(await res.json());
+```
+
+```py title="Python"
+import os, urllib.request
+
+url = f"{os.environ['PLEX_SERVER_URL']}/library/sections"
+req = urllib.request.Request(
+    url,
+    headers={
+        "X-Plex-Token": os.environ["PLEX_TOKEN"],
+        "Accept": "application/json",
+    },
+)
+with urllib.request.urlopen(req) as res:
+    print(res.read().decode())
+```
+</CodeGroup>
+
+You should receive a response containing one or more `Directory` entries representing your libraries.
+
+## Request JSON responses
+
+Plex returns XML by default. Add an `Accept` header to get JSON:
+
+```bash
+curl -H "X-Plex-Token: $PLEX_TOKEN" \
+  -H "Accept: application/json" \
+  "$PLEX_SERVER_URL/library/sections"
+```
+
+Many integrations prefer JSON, but some response fields and nested arrays are easier to read in XML. Use whichever format your tooling handles best.
+
+## List items in a library
+
+Use the library key from the previous response to list its contents. Replace `<library-key>` with the value of the `key` field, for example `1`:
+
+<CodeGroup>
+```bash title="curl"
+curl -H "X-Plex-Token: $PLEX_TOKEN" \
+  -H "Accept: application/json" \
+  "$PLEX_SERVER_URL/library/sections/<library-key>/all"
+```
+
+```js title="Node.js"
+const libraryKey = "<library-key>";
+const res = await fetch(
+  `${process.env.PLEX_SERVER_URL}/library/sections/${libraryKey}/all`,
+  {
+    headers: {
+      "X-Plex-Token": process.env.PLEX_TOKEN,
+      "Accept": "application/json",
+    },
+  }
+);
+console.log(await res.json());
+```
+
+```py title="Python"
+import os, urllib.request
+
+library_key = "<library-key>"
+url = f"{os.environ['PLEX_SERVER_URL']}/library/sections/{library_key}/all"
+req = urllib.request.Request(
+    url,
+    headers={
+        "X-Plex-Token": os.environ["PLEX_TOKEN"],
+        "Accept": "application/json",
+    },
+)
+with urllib.request.urlopen(req) as res:
+    print(res.read().decode())
+```
+</CodeGroup>
+
+## Check active sessions
+
+See what is currently playing on the server:
+
+<CodeGroup>
+```bash title="curl"
+curl -H "X-Plex-Token: $PLEX_TOKEN" \
+  -H "Accept: application/json" \
+  "$PLEX_SERVER_URL/status/sessions"
+```
+
+```js title="Node.js"
+const res = await fetch(`${process.env.PLEX_SERVER_URL}/status/sessions`, {
+  headers: {
+    "X-Plex-Token": process.env.PLEX_TOKEN,
+    "Accept": "application/json",
+  },
+});
+console.log(await res.json());
+```
+
+```py title="Python"
+import os, urllib.request
+
+url = f"{os.environ['PLEX_SERVER_URL']}/status/sessions"
+req = urllib.request.Request(
+    url,
+    headers={
+        "X-Plex-Token": os.environ["PLEX_TOKEN"],
+        "Accept": "application/json",
+    },
+)
+with urllib.request.urlopen(req) as res:
+    print(res.read().decode())
+```
+</CodeGroup>
+
+## Identify your client
+
+When you move beyond experiments, add `X-Plex-*` headers so the server knows which client is calling. See the [Authentication guide](./authentication) for the full list.
+
+## Next steps
+
+- Read the [Authentication guide](./authentication) for token management best practices and how to obtain a token.
+- Explore the [API Reference](/api-reference) for available endpoints and parameters.
+- Learn how to request `Accept: application/json` and interpret Plex XML responses.


### PR DESCRIPTION
Migrates the user-facing guides and reference overviews from [LukasParke/plexapi-dev-docs](https://github.com/LukasParke/plexapi-dev-docs) into this Mintlify documentation site.

## Changes

- Added `quick-start.mdx` — step-by-step first API call guide.
- Added `authentication.mdx` — token management and client identification guide.
- Added concept pages under `concepts/`:
  - `library.mdx`
  - `server.mdx`
  - `sessions.mdx`
- Updated `docs.json` to include new pages in the **Getting Started** and **Core concepts** groups.
- Updated `Intro.mdx` with prerequisites and links to new guides.
- Updated `Open-API-Specification.mdx` to point to the canonical `LukasParke/plex-api-spec` repository.
- Merged detailed content style rules from the old VitePress `contributing.md` into `contributing.mdx`.

## Verification

- `mintlify validate` ✅
- `mintlify broken-links` ✅
